### PR TITLE
remove locale from collection declaration, focusing on coercer

### DIFF
--- a/lib/locomotive/adapters/memory/command.rb
+++ b/lib/locomotive/adapters/memory/command.rb
@@ -8,22 +8,22 @@ module Locomotive
           @dataset, @collection = dataset, collection
         end
 
-        def create(entity)
+        def create(entity, locale)
           @dataset.create(
-            _serialize(entity)
+            _serialize(entity, locale)
           )
         end
 
-        def update(entity)
+        def update(entity, locale)
           @dataset.update(
-            _serialize(entity)
+            _serialize(entity, locale)
           )
         end
 
         private
 
-        def _serialize(entity)
-          @collection.serialize(entity)
+        def _serialize(entity, locale)
+          @collection.serialize(entity, locale)
         end
       end
     end

--- a/lib/locomotive/adapters/memory/dataset.rb
+++ b/lib/locomotive/adapters/memory/dataset.rb
@@ -37,7 +37,8 @@ module Locomotive
           records.values
         end
 
-        def find id
+        # memory adapter dont care about locale, it returns the whole record hash.
+        def find id, locale
           records[id]
         end
 

--- a/lib/locomotive/adapters/memory_adapter.rb
+++ b/lib/locomotive/adapters/memory_adapter.rb
@@ -16,15 +16,15 @@ module Locomotive
       end
 
       def all(collection, locale)
-        _mapped_collection(collection, locale).deserialize(dataset(collection).all)
+        _mapped_collection(collection).deserialize(dataset(collection).all, locale)
       end
 
       def create(collection, entity, locale)
-        Memory::Command.new(dataset(collection), _mapped_collection(collection, locale)).create(entity)
+        Memory::Command.new(dataset(collection), _mapped_collection(collection)).create(entity, locale)
       end
 
       def update(collection, entity, locale)
-        Memory::Command.new(dataset(collection), _mapped_collection(collection, locale)).update(entity)
+        Memory::Command.new(dataset(collection), _mapped_collection(collection)).update(entity, locale)
       end
 
       def first(collection)
@@ -46,9 +46,9 @@ module Locomotive
         # TODO move to query
       def find(collection, id, locale)
         
-        record = dataset(collection).find(id)
+        record = dataset(collection).find(id, locale)
         
-        _mapped_collection(collection, locale).deserialize([record]).first
+        _mapped_collection(collection).deserialize([record], locale).first
       end
 
       private
@@ -57,8 +57,8 @@ module Locomotive
         @datasets[collection]
       end
 
-      def _mapped_collection(name, locale)
-        @mapper.collection(name, locale)
+      def _mapped_collection(name)
+        @mapper.collection(name)
       end
 
     end

--- a/lib/locomotive/mapper.rb
+++ b/lib/locomotive/mapper.rb
@@ -8,9 +8,9 @@ module Locomotive
       instance_eval(&blk) if block_given?
     end
 
-    def collection(name, locale, &blk)
+    def collection(name, &blk)
       if block_given?
-        @collections[name] = Mapping::Collection.new(name, locale, &blk)
+        @collections[name] = Mapping::Collection.new(name, &blk)
       else
         @collections[name] or raise StandardError.new
       end

--- a/lib/locomotive/mapping/coercer.rb
+++ b/lib/locomotive/mapping/coercer.rb
@@ -6,12 +6,12 @@ module Locomotive
         @collection = collection
       end
 
-      def to_record(entity)
+      def to_record(entity, locale)
         {}.tap do |_attributes|
           _attributes[:id] = entity.id
           @collection.attributes.each do |name, options|
             if options[:localized]
-              _attributes[name] = { @collection.locale => entity.send(name) }
+              _attributes[name] = { locale => entity.send(name) }
             else
               _attributes[name] = entity.send(name)
             end
@@ -19,14 +19,14 @@ module Locomotive
         end
       end
 
-      def from_record(record)
+      def from_record(record, locale)
 
         _entity = @collection.entity.new(id: record[:id])
 
         @collection.attributes.each do |name, options|
           
           if options[:localized]
-            _entity.send(:"#{name}=", record[name][@collection.locale])
+            _entity.send(:"#{name}=", record[name][locale])
           else
             _entity.send(:"#{name}=", record[name])
           end

--- a/lib/locomotive/mapping/collection.rb
+++ b/lib/locomotive/mapping/collection.rb
@@ -2,11 +2,10 @@ module Locomotive
   module Mapping
     class Collection
 
-      attr_reader :locale, :attributes
+      attr_reader :attributes
 
-      def initialize entity, locale, &blk
+      def initialize entity, &blk
         @coercer = Coercer.new(self)
-        @locale = locale
         @attributes = {}
         instance_eval(&blk) if block_given?
       end
@@ -23,15 +22,15 @@ module Locomotive
         @attributes[name] = options
       end
 
-      def serialize(record)
+      def serialize(record, locale)
 
-        @coercer.to_record(record)
+        @coercer.to_record(record, locale)
       end
 
-      def deserialize(records)
+      def deserialize(records, locale)
         
         records.map do |record|
-          @coercer.from_record(record)
+          @coercer.from_record(record, locale)
         end
       end
 

--- a/lib/locomotive/repository.rb
+++ b/lib/locomotive/repository.rb
@@ -2,26 +2,17 @@ module Locomotive
 
   module Repository
 
-    def initialize(datastore, adapter, _locale)
+    def initialize(datastore, adapter)
       @datastore  = datastore
       @adapter    = adapter
-      self.locale = _locale
-    end
-
-    def locale
-      @locale
-    end
-
-    def locale= locale
-      @locale = locale
     end
 
     def all(locale)
       @adapter.all(collection, locale)
     end
 
-    def find(slug)
-      @adapter.find(collection, slug, locale)
+    def find(id, locale)
+      @adapter.find(collection, id, locale)
     end
 
     def query(&block)
@@ -37,8 +28,7 @@ module Locomotive
     end
 
     def collection
-      # TODO: mapper will go here
-      self.class.name.split("::").last.sub(/Repository$/, '').scan(/[A-Z][a-z]*/).join("_").downcase.to_sym
+      self.class.name.split("::").last.sub(/Repository\Z/, '').scan(/[A-Z][a-z]*/).join("_").downcase.to_sym
     end
   end
 end

--- a/spec/integration/persistence_entity_spec.rb
+++ b/spec/integration/persistence_entity_spec.rb
@@ -17,14 +17,14 @@ module Locomotive
     let(:repository) do
       class DummyRepository
         include Repository
-      end.new(datastore, adapter, locale)
+      end.new(datastore, adapter)
     end
     let(:datastore) { Locomotive::Datastore.new }
     let(:adapter)   { Locomotive::Adapters::MemoryAdapter.new(mapper) }
     let(:locale)    { :en }
     let(:mapper) do
       Locomotive::Mapper.new do
-        collection :dummy, :en do
+        collection :dummy do
           entity Entities::Dummy
           attribute :name, localized: true
         end
@@ -46,7 +46,7 @@ module Locomotive
     describe 'finding an entity by its ID' do
       context 'when entity exists' do
         before  { repository.create(entity, locale) }
-        subject { repository.find(entity.id) }
+        subject { repository.find(entity.id, locale) }
 
         it { should be_kind_of Entities::Dummy }
         its(:id) { should_not be_nil }


### PR DESCRIPTION
The main goal was to remove the need for a locale to collection so it does not interfere in the mapper definition. 
Now locale must be passed for each command or query (yet TODO for the Query class).
