### PR TITLE
Locale in i18nfield

### DIFF
--- a/lib/locomotive/entity.rb
+++ b/lib/locomotive/entity.rb
@@ -1,7 +1,7 @@
 module Locomotive
   module Entity
 
-    attr_accessor :id, :locale
+    attr_accessor :id
 
     def self.included(base)
       base.extend ClassMethods

--- a/lib/locomotive/fields/i18n_field.rb
+++ b/lib/locomotive/fields/i18n_field.rb
@@ -15,9 +15,8 @@ module Locomotive
       # alias :values= :i18n_values=
       alias :values  :i18n_values
 
-      def initialize i18n_values = nil, _current_locale = nil
+      def initialize i18n_values = nil
         @i18n_values = I18nValues.new
-        self.current_locale = _current_locale
         self << i18n_values
       end
 
@@ -36,17 +35,9 @@ module Locomotive
         @i18n_values.keys
       end
 
-      def current_locale= locale
-        @current_locale = locale.try(:to_sym)
-      end
-
-      def current_locale
-        @current_locale ||= i18n_values.keys.first
-      end
-
       def to_s locale = nil
-        if (str = i18n_values.fetch(locale) { i18n_values[current_locale] })
-          str
+        if locale
+          i18n_values.fetch(locale)
         else
           "#<Foo: @i18n_values=>{" + i18n_values.map{|k,v|":#{k}=>#{v}"}.join(',') + '}>'
         end

--- a/lib/locomotive/fields/i18n_field.rb
+++ b/lib/locomotive/fields/i18n_field.rb
@@ -3,6 +3,8 @@ module Locomotive
     class I18nField
 
       class UnsupportedFormat < StandardError ; end
+      class NoLocaleError < StandardError ; end
+      class EmptyLocaleError < StandardError ; end
 
       class I18nValues < Hash
         def method_missing method_name, *args
@@ -12,8 +14,10 @@ module Locomotive
       end
 
       attr_accessor :i18n_values
-      # alias :values= :i18n_values=
-      alias :values  :i18n_values
+
+      def values
+        i18n_values.values
+      end
 
       def initialize i18n_values = nil
         @i18n_values = I18nValues.new
@@ -37,9 +41,13 @@ module Locomotive
 
       def to_s locale = nil
         if locale
-          i18n_values.fetch(locale)
+          i18n_values.fetch(locale) do
+            raise NoLocaleError
+          end.tap do |value|
+            raise EmptyLocaleError if value.empty?
+          end
         else
-          "#<Foo: @i18n_values=>{" + i18n_values.map{|k,v|":#{k}=>#{v}"}.join(',') + '}>'
+          "#<I18nField: @i18n_values=>{" + i18n_values.map{|k,v|":#{k}=>#{v}"}.join(',') + '}>'
         end
       end
       alias_method :inspect, :to_s

--- a/lib/locomotive/fields/i18n_field.rb
+++ b/lib/locomotive/fields/i18n_field.rb
@@ -15,8 +15,9 @@ module Locomotive
       # alias :values= :i18n_values=
       alias :values  :i18n_values
 
-      def initialize i18n_values = nil
+      def initialize i18n_values = nil, _current_locale = nil
         @i18n_values = I18nValues.new
+        self.current_locale = _current_locale
         self << i18n_values
       end
 
@@ -35,8 +36,16 @@ module Locomotive
         @i18n_values.keys
       end
 
+      def current_locale= locale
+        @current_locale = locale.try(:to_sym)
+      end
+
+      def current_locale
+        @current_locale ||= i18n_values.keys.first
+      end
+
       def to_s locale = nil
-        if (str = i18n_values.fetch(locale) { i18n_values.values.first })
+        if (str = i18n_values.fetch(locale) { i18n_values[current_locale] })
           str
         else
           "#<Foo: @i18n_values=>{" + i18n_values.map{|k,v|":#{k}=>#{v}"}.join(',') + '}>'

--- a/lib/locomotive/models/decorators.rb
+++ b/lib/locomotive/models/decorators.rb
@@ -1,0 +1,1 @@
+require_relative 'decorators/i18n_decorator'

--- a/lib/locomotive/models/decorators/i18n_decorator.rb
+++ b/lib/locomotive/models/decorators/i18n_decorator.rb
@@ -9,6 +9,11 @@ module Locomotive
         end
       end
 
+      def initialize(object, locale = nil)
+        self.current_locale = locale
+        super(object)
+      end
+
       def method_missing(name, *args, &block)
         begin
           __getobj__.public_send(name)[current_locale]

--- a/lib/locomotive/models/decorators/i18n_decorator.rb
+++ b/lib/locomotive/models/decorators/i18n_decorator.rb
@@ -3,6 +3,8 @@ module Locomotive
     class I18nDecorator < SimpleDelegator
 
       attr_accessor :current_locale
+      attr_writer :on_no_locale, :on_empty_locale
+
       class << self
         def decorate(resultset, locale = nil)
           resultset.map { |obj| new(obj).tap {|decorated_obj| decorated_obj.current_locale = locale} }
@@ -16,10 +18,22 @@ module Locomotive
 
       def method_missing(name, *args, &block)
         begin
-          __getobj__.public_send(name)[current_locale]
-        rescue TypeError
+          __getobj__.public_send(name).to_s(current_locale)
+        rescue Locomotive::Fields::I18nField::NoLocaleError
+          on_no_locale.call __getobj__.send(:name), current_locale
+        rescue Locomotive::Fields::I18nField::EmptyLocaleError
+          on_empty_locale.call __getobj__.send(:name), current_locale
+        rescue ArgumentError
           super
         end
+      end
+
+      def on_no_locale
+        @on_no_locale ||= Proc.new { |field, locale| nil }
+      end
+
+      def on_empty_locale
+        @on_empty_locale ||= Proc.new { |field, locale| field.values.first }
       end
 
     end

--- a/lib/locomotive/models/decorators/i18n_decorator.rb
+++ b/lib/locomotive/models/decorators/i18n_decorator.rb
@@ -1,0 +1,22 @@
+module Locomotive
+  module Decorators
+    class I18nDecorator < SimpleDelegator
+
+      attr_accessor :current_locale
+      class << self
+        def decorate(resultset, locale = nil)
+          resultset.map { |obj| new(obj).tap {|decorated_obj| decorated_obj.current_locale = locale} }
+        end
+      end
+
+      def method_missing(name, *args, &block)
+        begin
+          __getobj__.public_send(name)[current_locale]
+        rescue TypeError
+          super
+        end
+      end
+
+    end
+  end
+end

--- a/spec/integration/criteria_spec.rb
+++ b/spec/integration/criteria_spec.rb
@@ -22,10 +22,10 @@ describe 'query' do
 
       specify('can be chained') do
         expect(
-          title = articles_repository.query(locale) do
+          articles_repository.query(locale) do
             where('content.eq' => 'content 1').
             where('id.lt' => 2)
-          end.first.title.to_s
+          end.first.title[:en]
         ).to eq('Screen 1')
       end
 
@@ -34,7 +34,7 @@ describe 'query' do
           articles_repository.query(locale) do
             where('title.eq' => 'Screen 2')
             where('id.gt' => 1)
-          end.first.title.to_s
+          end.first.title[:en]
         ).to eq('Screen 2')
       end
 

--- a/spec/unit/decorators/i18n_decorator_spec.rb
+++ b/spec/unit/decorators/i18n_decorator_spec.rb
@@ -52,9 +52,8 @@ describe Locomotive::Decorators::I18nDecorator do
     context 'when field is an i18n field' do
       let(:name) { { en: 'blah', fr: 'bla' } }
       context 'no current locale' do
-        # TODO redundant test here ( @see fields/i18n_field_spec.rb )
-        it 'falls back to default locale' do
-          subject.should eql 'blah'
+        it 'displays object for inspection' do
+          subject.should eql '#<Foo: @i18n_values=>{:en=>blah,:fr=>bla}>'
         end
       end
 
@@ -81,13 +80,25 @@ describe Locomotive::Decorators::I18nDecorator do
       let(:decorated_set) do
         Locomotive::Decorators::I18nDecorator.decorate(entities)
       end
-      it { should eq 'blah' }
+      it 'displays object for inspection' do
+        subject.should eq '#<Foo: @i18n_values=>{:en=>blah,:fr=>bla}>'
+      end
     end
-    context 'when locale is set in a given block' do
+
+    context 'when locale is passed in the constructor' do
       let(:decorated_set) do
         Locomotive::Decorators::I18nDecorator.decorate(entities, :fr)
       end
       it { should eq 'bla' }
+    end
+
+    context 'when passed locale does not exist' do
+      let(:decorated_set) do
+        Locomotive::Decorators::I18nDecorator.decorate(entities, :wk)
+      end
+      it 'raises an error' do
+        expect { subject }.to raise_error
+      end
     end
   end
 end

--- a/spec/unit/decorators/i18n_decorator_spec.rb
+++ b/spec/unit/decorators/i18n_decorator_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'locomotive/models/decorators'
+
+describe Locomotive::Decorators::I18nDecorator, focused: true do
+
+  class FakeEntity
+    include Locomotive::Entity
+    attributes :name, :description
+  end
+
+  describe 'initialization' do
+    context 'with instance' do
+      subject do
+        Locomotive::Decorators::I18nDecorator.new(FakeEntity.new)
+      end
+
+      it 'accepts an entity as parameter' do
+        subject.should be_kind_of Locomotive::Decorators::I18nDecorator
+      end
+
+      it 'responds to all entity attributes' do
+        subject.should respond_to :name
+        subject.should respond_to :description
+        subject.should respond_to :name=
+        subject.should respond_to :description=
+      end
+    end
+
+    context 'with resultset' do
+      let(:entities) {
+        [ FakeEntity.new, FakeEntity.new ]
+      }
+      it 'decorates each entity' do
+        Locomotive::Decorators::I18nDecorator.decorate(entities).each do |entity|
+          entity.should be_kind_of(Locomotive::Decorators::I18nDecorator)
+        end
+      end
+    end
+  end
+
+  describe 'fields on single instance' do
+
+    subject { decorator.name.to_s }
+    let(:decorator) { Locomotive::Decorators::I18nDecorator.new(entity) }
+    let(:entity) { FakeEntity.new(name: name) }
+
+    context 'when field is not an i18n field' do
+      let(:name) { 'blah' }
+      it { should eql 'blah' }
+    end
+
+    context 'when field is an i18n field' do
+      let(:name) { { en: 'blah', fr: 'bla' } }
+      context 'no current locale' do
+        # TODO redundant test here ( @see fields/i18n_field_spec.rb )
+        it 'falls back to default locale' do
+          subject.should eql 'blah'
+        end
+      end
+
+      context 'with current locale' do
+        before { decorator.current_locale = :fr }
+        it { should eql 'bla' }
+      end
+    end
+  end
+
+  describe 'fields on resultset' do
+    subject { decorated_set.first.name.to_s }
+    let(:entities) {
+      [ FakeEntity.new(name: { en: 'blah', fr: 'bla'}),
+        FakeEntity.new
+      ]
+    }
+    context 'when no block is given' do
+      let(:decorated_set) do
+        Locomotive::Decorators::I18nDecorator.decorate(entities)
+      end
+      it { should eq 'blah' }
+    end
+    context 'when locale is set in a given block' do
+      let(:decorated_set) do
+        Locomotive::Decorators::I18nDecorator.decorate(entities, :fr)
+      end
+      it { should eq 'bla' }
+    end
+  end
+end

--- a/spec/unit/decorators/i18n_decorator_spec.rb
+++ b/spec/unit/decorators/i18n_decorator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'locomotive/models/decorators'
 
-describe Locomotive::Decorators::I18nDecorator, focused: true do
+describe Locomotive::Decorators::I18nDecorator do
 
   class FakeEntity
     include Locomotive::Entity
@@ -60,6 +60,11 @@ describe Locomotive::Decorators::I18nDecorator, focused: true do
 
       context 'with current locale' do
         before { decorator.current_locale = :fr }
+        it { should eql 'bla' }
+      end
+
+      context 'passing current locale in constructor' do
+        let(:decorator) { Locomotive::Decorators::I18nDecorator.new(entity, :fr) }
         it { should eql 'bla' }
       end
     end

--- a/spec/unit/entity_spec.rb
+++ b/spec/unit/entity_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Locomotive::Entity do
-  
+
   class FakeEntity
     include Locomotive::Entity
     attributes :name, :description
@@ -11,7 +11,7 @@ describe Locomotive::Entity do
     subject { FakeEntity.new }
     it { should be_a FakeEntity }
     it { should respond_to :name }
-    it { should respond_to :name= }    
+    it { should respond_to :name= }
   end
 
   context 'with empty hash' do
@@ -24,6 +24,7 @@ describe Locomotive::Entity do
     subject { FakeEntity.new({name: 'John'}) }
     it { should be_a FakeEntity }
     its(:name) { should eq 'John' }
-    its(:description) { should be_nil }    
+    its(:description) { should be_nil }
   end
+
 end

--- a/spec/unit/fields/i18n_field_spec.rb
+++ b/spec/unit/fields/i18n_field_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Locomotive::Fields::I18nField do
+
+  subject { Locomotive::Fields::I18nField.new(values, locale) }
+  let(:values) { { wk: 'Tik wrzeidl', en: 'My value', es: 'Mi valor' } }
+  let(:locale) { nil }
+  describe '#to_s' do
+
+    context 'when no current locale is set' do
+      let(:locale) { nil }
+      it 'falls back to first value in hash' do
+        subject.to_s.should eql 'Tik wrzeidl'
+      end
+    end
+
+    context 'when current locale set' do
+      let(:locale) { :en }
+      it { subject.to_s.should eql 'My value' }
+    end
+  end
+
+  describe 'alternative access' do
+    it { subject.en.should eq 'My value' }
+    it { subject[:en].should eq 'My value' }
+    it { subject.to_s(:en).should eq 'My value' }
+  end
+end

--- a/spec/unit/fields/i18n_field_spec.rb
+++ b/spec/unit/fields/i18n_field_spec.rb
@@ -2,27 +2,21 @@ require 'spec_helper'
 
 describe Locomotive::Fields::I18nField do
 
-  subject { Locomotive::Fields::I18nField.new(values, locale) }
+  subject { Locomotive::Fields::I18nField.new(values) }
   let(:values) { { wk: 'Tik wrzeidl', en: 'My value', es: 'Mi valor' } }
-  let(:locale) { nil }
   describe '#to_s' do
-
-    context 'when no current locale is set' do
-      let(:locale) { nil }
-      it 'falls back to first value in hash' do
-        subject.to_s.should eql 'Tik wrzeidl'
+    context 'no params' do
+      it 'displays object inspection' do
+        subject.to_s.should eql '#<Foo: @i18n_values=>{:wk=>Tik wrzeidl,:en=>My value,:es=>Mi valor}>'
       end
     end
-
-    context 'when current locale set' do
-      let(:locale) { :en }
-      it { subject.to_s.should eql 'My value' }
+    context 'locale as param' do
+      it { subject.to_s(:en).should eq 'My value' }
     end
   end
 
   describe 'alternative access' do
     it { subject.en.should eq 'My value' }
     it { subject[:en].should eq 'My value' }
-    it { subject.to_s(:en).should eq 'My value' }
   end
 end

--- a/spec/unit/fields/i18n_field_spec.rb
+++ b/spec/unit/fields/i18n_field_spec.rb
@@ -3,15 +3,25 @@ require 'spec_helper'
 describe Locomotive::Fields::I18nField do
 
   subject { Locomotive::Fields::I18nField.new(values) }
-  let(:values) { { wk: 'Tik wrzeidl', en: 'My value', es: 'Mi valor' } }
+  let(:values) { { wk: '', en: 'My value', es: 'Mi valor' } }
   describe '#to_s' do
     context 'no params' do
       it 'displays object inspection' do
-        subject.to_s.should eql '#<Foo: @i18n_values=>{:wk=>Tik wrzeidl,:en=>My value,:es=>Mi valor}>'
+        subject.to_s.should eql '#<I18nField: @i18n_values=>{:wk=>,:en=>My value,:es=>Mi valor}>'
       end
     end
     context 'locale as param' do
       it { subject.to_s(:en).should eq 'My value' }
+    end
+    context 'non existing locale as param' do
+      it 'raises an error' do
+        expect{ subject.to_s(:kz) }.to raise_error(Locomotive::Fields::I18nField::NoLocaleError)
+      end
+    end
+    context 'empty translation' do
+      it 'raises an error' do
+        expect{ subject.to_s(:wk) }.to raise_error(Locomotive::Fields::I18nField::EmptyLocaleError)
+      end
     end
   end
 


### PR DESCRIPTION
``` !ruby

article1 = Article.new(title: {en: 'Article title', fr: 'Titre article'})
article2 = Article.new(title: {en: 'Other article title', fr: 'Titre autre article'})
resultset = [article1, article2]

decorated = Locomotive::Decorators::I18nDecorator.new(article1, :fr)

decorated.title # => Titre article

decorated.current_locale = :en
decorated.title # => Article title

decorated_result = Locomotive::Decorators::I18nDecorator.decorate(resultset, :fr)

decorated_result.last.title # => Titre autre article

decorated.title[:fr]=''
decorated.current_locale = :fr

# default callback behaviour : first locale
decorated.title # 'Other article title'

# custom callback behaviour
decorated.on_empty_callback = Proc.new { |fields, locale| "Missing translation #{locale}" }

decorated.title # 'Missing translation fr'

decorated.on_empty_callback = Proc.new { |fields, locale| nil }

decorated.title # nil
```
